### PR TITLE
候选字间距由margin改为padding

### DIFF
--- a/src/main/res/layout/sdk_item_recyclerview_candidates_bar.xml
+++ b/src/main/res/layout/sdk_item_recyclerview_candidates_bar.xml
@@ -9,5 +9,5 @@
     android:singleLine="true"
     android:gravity="center"
     android:minWidth="20dp"
-    android:layout_marginStart="10dp"
-    android:layout_marginEnd="10dp"/>
+    android:paddingStart="10dp"
+    android:paddingEnd="10dp"/>


### PR DESCRIPTION
候选字中间目前是用margin，会出现点击问题。也就是看着明明去点了，却发现点不到字。本质是点击范围不足，点击位点不在字上时，而手指是可以覆盖候选字的，可以通过把margin修改为padding解决