### PR TITLE
修复全拼模式下输入错误拼写后不显示拼音候选的问题

### DIFF
--- a/src/main/java/com/yuyan/inputmethod/RimeEngine.kt
+++ b/src/main/java/com/yuyan/inputmethod/RimeEngine.kt
@@ -267,13 +267,30 @@ object RimeEngine {
             }
             else -> {
                 val compositionList = composition.filter { it.code <= 0xFF }.split("'".toRegex())
+                var pos = 0
                 buildSpannedString {
                     append(composition.filter { it.code > 0xFF })
                     comment.split("'").zip(compositionList).forEach { (pinyin, composition) ->
-                        append(if (composition.length >= pinyin.length) pinyin else pinyin.substring(0, composition.length))
+                        if (composition.length >= pinyin.length) {
+                            pos += pinyin.length
+                            append(pinyin)
+                        }
+                        else {
+                            val temp = pinyin.substring(0, composition.length)
+                            pos += composition.length
+                            append(temp)
+                        }
                         append("'")
+                        pos += 1
                     }
-                    if (!composition.endsWith("'")) delete(length - 1, length)
+                    if (!composition.endsWith("'")) {
+                        pos -= 1
+                        delete(length - 1, length)
+                    }
+                    if (pos < composition.length) {
+                        append("'")
+                        append(composition.substring(pos, composition.length))
+                    }
                 }
             }
         }


### PR DESCRIPTION
详见 gurecn/YuyanIme#427 和 gurecn/YuyanIme#437

主要问题在`RimeEngine.kt`的这部分：
```kotlin
// line 269
val compositionList = composition.filter { it.code <= 0xFF }.split("'".toRegex())
buildSpannedString {
    append(composition.filter { it.code > 0xFF })
    comment.split("'").zip(compositionList).forEach { (pinyin, composition) ->
        append(if (composition.length >= pinyin.length) pinyin else pinyin.substring(0, composition.length))
        append("'")
    }
    if (!composition.endsWith("'")) delete(length - 1, length)
}
```

按照候选词确定好拼音的分词以后，多余的不能识别的部分（也就是错误拼写的部分）被忽略掉了，但是`RimeEngine.showComposition`里还存着完整的输入

简单测试了一下没啥问题
![1](https://github.com/user-attachments/assets/8c767ff0-3826-4081-a7a5-f5a904daeb25)
![2](https://github.com/user-attachments/assets/5c1f540d-4b56-4b35-9adc-7427fa3b886a)

这是我第一次写Kotlin，如果代码有什么问题请随时建议修改或拒绝合并