### PR TITLE
fix(ime):修复乱序17无法输入yo

### DIFF
--- a/src/main/java/com/yuyan/inputmethod/util/LX17PinYinUtils.kt
+++ b/src/main/java/com/yuyan/inputmethod/util/LX17PinYinUtils.kt
@@ -196,7 +196,7 @@ object LX17PinYinUtils {
         lx17PinyinMap.put("YS", "yin")
         lx17PinyinMap.put("YZ", "yang")
         lx17PinyinMap.put("YB", "yao")
-        lx17PinyinMap.put("YX", "yuan")
+        lx17PinyinMap.put("YX", "yuan,yo")
         lx17PinyinMap.put("YL", "yue")
         lx17PinyinMap.put("YD", "yu")
         lx17PinyinMap.put("YY", "ying")

--- a/src/main/java/com/yuyan/inputmethod/util/LX17PinYinUtils.kt
+++ b/src/main/java/com/yuyan/inputmethod/util/LX17PinYinUtils.kt
@@ -188,7 +188,7 @@ object LX17PinYinUtils {
         lx17PinyinMap.put("DN", "dan")
         lx17PinyinMap.put("DC", "dui")
         lx17PinyinMap.put("DQ", "duang,dian")
-        lx17PinyinMap.put("DG", "dun")
+        lx17PinyinMap.put("DG", "dun,dei")
         lx17PinyinMap.put("DF", "diu,dou")
         lx17PinyinMap.put("DT", "dong")
 
@@ -344,7 +344,7 @@ object LX17PinYinUtils {
         lx17PinyinMap.put("TN", "tan")
         lx17PinyinMap.put("TC", "tui")
         lx17PinyinMap.put("TQ", "tian")
-        lx17PinyinMap.put("TG", "tun")
+        lx17PinyinMap.put("TG", "tun,tei")
         lx17PinyinMap.put("TF", "tou")
         lx17PinyinMap.put("TT", "tong")
     }


### PR DESCRIPTION
修复问题：

* 乱序17无法输入拼音yo（哟、唷）

变更列表：

* 增加YX到yo的映射

测试：

* ColorOS 16.0.3 (Android 16)