### PR TITLE
fix(ime):修复乱序17无法输入dei、tei

### DIFF
--- a/src/main/java/com/yuyan/inputmethod/util/LX17PinYinUtils.kt
+++ b/src/main/java/com/yuyan/inputmethod/util/LX17PinYinUtils.kt
@@ -188,7 +188,7 @@ object LX17PinYinUtils {
         lx17PinyinMap.put("DN", "dan")
         lx17PinyinMap.put("DC", "dui")
         lx17PinyinMap.put("DQ", "duang,dian")
-        lx17PinyinMap.put("DG", "dun")
+        lx17PinyinMap.put("DG", "dun,dei")
         lx17PinyinMap.put("DF", "diu,dou")
         lx17PinyinMap.put("DT", "dong")
 
@@ -344,7 +344,7 @@ object LX17PinYinUtils {
         lx17PinyinMap.put("TN", "tan")
         lx17PinyinMap.put("TC", "tui")
         lx17PinyinMap.put("TQ", "tian")
-        lx17PinyinMap.put("TG", "tun")
+        lx17PinyinMap.put("TG", "tun,tei")
         lx17PinyinMap.put("TF", "tou")
         lx17PinyinMap.put("TT", "tong")
     }


### PR DESCRIPTION
fix https://github.com/gurecn/YuyanIme/issues/725#issue-3755627561

增加了dei和tei的拼音。实测在开启乱序17拼音选择的情况下能用。但是关闭拼音选择后还是没有，目前怀疑是有别的问题，下一步准备和 https://github.com/gurecn/YuyanIme/issues/774 https://github.com/gurecn/YuyanIme/issues/730 等一起查一下。
