### PR TITLE
feat(ime): 添加邮箱联想功能

### DIFF
--- a/src/main/java/com/yuyan/imemodule/keyboard/InputView.kt
+++ b/src/main/java/com/yuyan/imemodule/keyboard/InputView.kt
@@ -511,7 +511,7 @@ class InputView(context: Context, private val service: ImeService) : LifecycleRe
         if (candidate?.comment == "📋") {
             commitDecInfoText(candidate.text)
         } else if (candidate != null && candidate.comment == "" && DecodingInfo.isAssociate
-            && InputModeSwitcher.isEnglish && CustomEngine.EMAIL_DOMAINS.contains(candidate.text)) {
+            && CustomEngine.EMAIL_DOMAINS.contains(candidate.text)) {
             commitEmailDomain(candidate.text)
         } else {
             val choice = DecodingInfo.chooseDecodingCandidate(candId)
@@ -754,14 +754,15 @@ class InputView(context: Context, private val service: ImeService) : LifecycleRe
     fun onUpdateSelection(oldSelStart: Int, oldSelEnd: Int, newSelStart: Int, newSelEnd: Int, candidatesEnd: Int) {
         selStart = newSelStart
         selEnd = newSelEnd
-        if (InputModeSwitcher.isEnglish ) {
-            val emails = if (emailSuggestion && !isAddPhrases)
-                CustomEngine.emailSuggestions(service.getTextBeforeCursor(100)) else emptyList()
+        if (emailSuggestion && !isAddPhrases) {
+            val emails = CustomEngine.emailSuggestions(service.getTextBeforeCursor(100))
             if (emails.isNotEmpty()) {
                 DecodingInfo.cacheCandidates(emails.map { CandidateListItem("", it) }.toTypedArray(), true)
                 oldCandidatesEnd = candidatesEnd
                 return
             }
+        }
+        if (InputModeSwitcher.isEnglish ) {
             if (oldCandidatesEnd == candidatesEnd || DecodingInfo.isAssociate) {
                 service.finishComposingText()
                 resetToIdleState()

--- a/src/main/java/com/yuyan/imemodule/keyboard/InputView.kt
+++ b/src/main/java/com/yuyan/imemodule/keyboard/InputView.kt
@@ -73,6 +73,7 @@ class InputView(context: Context, private val service: ImeService) : LifecycleRe
     private val appPrefs = getInstance()
     private val clipboardItemTimeout = appPrefs.clipboard.clipboardItemTimeout.getValue()
     private var chinesePrediction = true
+    private var emailSuggestion = false
     var isAddPhrases = false
     private val mChoiceNotifier = ChoiceNotifier()
     var mSkbRoot: RelativeLayout
@@ -509,6 +510,9 @@ class InputView(context: Context, private val service: ImeService) : LifecycleRe
         val candidate = DecodingInfo.getCandidate(candId)
         if (candidate?.comment == "📋") {
             commitDecInfoText(candidate.text)
+        } else if (candidate != null && candidate.comment == "" && DecodingInfo.isAssociate
+            && InputModeSwitcher.isEnglish && CustomEngine.EMAIL_DOMAINS.contains(candidate.text)) {
+            commitEmailDomain(candidate.text)
         } else {
             val choice = DecodingInfo.chooseDecodingCandidate(candId)
             if (DecodingInfo.isCandidatesEmpty || DecodingInfo.isAssociate) {
@@ -665,6 +669,22 @@ class InputView(context: Context, private val service: ImeService) : LifecycleRe
         }
     }
 
+    /**
+     * 上屏邮箱域名：删除@后已输入的部分域名，补全域名后缀（原样上屏，不转花漾字）
+     */
+    private fun commitEmailDomain(domain: String) {
+        if (isAddPhrases) return
+        service.finishComposingText()
+        val partial = CustomEngine.parseEmailAtEnd(service.getTextBeforeCursor(100))?.second
+        if (partial == null) { // 光标处已非邮箱输入状态，中止上屏
+            resetToIdleState()
+            return
+        }
+        if (partial.isNotEmpty()) service.deleteSurroundingText(partial.length)
+        service.commitRawText(domain)
+        resetToIdleState()
+    }
+
     private fun initNavbarBackground(service: ImeService) {
         service.window.window?.also { win ->
             WindowCompat.setDecorFitsSystemWindows(win, false)
@@ -714,6 +734,7 @@ class InputView(context: Context, private val service: ImeService) : LifecycleRe
 
     fun onWindowShown() {
         chinesePrediction = appPrefs.input.chinesePrediction.getValue()
+        emailSuggestion = appPrefs.input.emailSuggestion.getValue()
     }
 
     fun onWindowHidden() {
@@ -734,7 +755,14 @@ class InputView(context: Context, private val service: ImeService) : LifecycleRe
         selStart = newSelStart
         selEnd = newSelEnd
         if (InputModeSwitcher.isEnglish ) {
-            if (oldCandidatesEnd == candidatesEnd) {
+            val emails = if (emailSuggestion && !isAddPhrases)
+                CustomEngine.emailSuggestions(service.getTextBeforeCursor(100)) else emptyList()
+            if (emails.isNotEmpty()) {
+                DecodingInfo.cacheCandidates(emails.map { CandidateListItem("", it) }.toTypedArray(), true)
+                oldCandidatesEnd = candidatesEnd
+                return
+            }
+            if (oldCandidatesEnd == candidatesEnd || DecodingInfo.isAssociate) {
                 service.finishComposingText()
                 resetToIdleState()
             }

--- a/src/main/java/com/yuyan/imemodule/prefs/AppPrefs.kt
+++ b/src/main/java/com/yuyan/imemodule/prefs/AppPrefs.kt
@@ -104,6 +104,11 @@ class AppPrefs(private val sharedPreferences: SharedPreferences) {
             abcSearchEnglishCell.getValue()
         }
 
+        // 邮箱联想
+        val emailSuggestion = switch(
+            R.string.email_suggestion, "email_suggestion_enable", true
+        )
+
         val titleEmoji = category(R.string.emoji_setting)
         val emojiInput = switch(
             R.string.emoji_input, "emoji_input_enable", true

--- a/src/main/java/com/yuyan/imemodule/service/ImeService.kt
+++ b/src/main/java/com/yuyan/imemodule/service/ImeService.kt
@@ -273,6 +273,13 @@ class ImeService : InputMethodService() {
         currentInputConnection.commitText(StringUtils.converted2FlowerTypeface(text), newCursorPosition)
     }
 
+    /**
+     * 发送原始字符串给编辑框（不做花漾字转换）
+     */
+    fun commitRawText(text: String) {
+        currentInputConnection.commitText(text, 1)
+    }
+
     fun getTextBeforeCursor(length:Int) : String {
         return currentInputConnection.getTextBeforeCursor(length, 0).toString()
     }

--- a/src/main/java/com/yuyan/inputmethod/CustomEngine.kt
+++ b/src/main/java/com/yuyan/inputmethod/CustomEngine.kt
@@ -58,12 +58,12 @@ object CustomEngine {
         "sina.com", "sohu.com", "139.com", "189.cn", "aliyun.com", "hotmail.com"
     )
 
-    // 邮箱后缀匹配正则：本地部分（任意字符，支持中文）@域名部分（域名可含字母数字.-）
-    private val emailEndPattern = "(.+)@([A-Za-z0-9.-]*)\\z".toRegex()
+    // 邮箱后缀匹配正则：本地部分（任意字符，可为空，支持中文）@域名部分（域名可含字母数字.-）
+    private val emailEndPattern = "(.*)@([A-Za-z0-9.-]*)\\z".toRegex()
 
     /**
      * 解析文本末尾的邮箱输入
-     * @return Pair(localPart, partialDomain) 或 null（无匹配或本地部分为空）
+     * @return Pair(localPart, partialDomain) 或 null（无@或域名部分超长）
      */
     fun parseEmailAtEnd(text: String): Pair<String, String>? {
         val match = emailEndPattern.find(text) ?: return null

--- a/src/main/java/com/yuyan/inputmethod/CustomEngine.kt
+++ b/src/main/java/com/yuyan/inputmethod/CustomEngine.kt
@@ -52,6 +52,34 @@ object CustomEngine {
         return associations
     }
 
+    // 内置常见邮箱域名
+    val EMAIL_DOMAINS = arrayOf(
+        "qq.com", "163.com", "126.com", "gmail.com", "outlook.com", "foxmail.com",
+        "sina.com", "sohu.com", "139.com", "189.cn", "aliyun.com", "hotmail.com"
+    )
+
+    // 邮箱后缀匹配正则：本地部分@域名部分（域名可含字母数字.-）
+    private val emailEndPattern = "([A-Za-z0-9._%+-]+)@([A-Za-z0-9.-]*)\\z".toRegex()
+
+    /**
+     * 解析文本末尾的邮箱输入
+     * @return Pair(localPart, partialDomain) 或 null（无匹配或本地部分为空）
+     */
+    fun parseEmailAtEnd(text: String): Pair<String, String>? {
+        val match = emailEndPattern.find(text) ?: return null
+        val partial = match.groupValues[2]
+        if (partial.length >= EMAIL_DOMAINS.maxOf { it.length }) return null // 已超最长域名，无需联想
+        return Pair(match.groupValues[1], partial)
+    }
+
+    /**
+     * 获取邮箱域名联想列表：严格长于已输入部分的前缀匹配（忽略大小写）
+     */
+    fun emailSuggestions(text: String): List<String> {
+        val (_, partial) = parseEmailAtEnd(text) ?: return emptyList()
+        return EMAIL_DOMAINS.filter { it.length > partial.length && it.startsWith(partial, ignoreCase = true) }
+    }
+
     fun processPhrase(text: String):MutableList<String> {
         val phrases = mutableListOf<String>()
         val chinesePredictionDate = getInstance().input.chinesePredictionDate.getValue()

--- a/src/main/java/com/yuyan/inputmethod/CustomEngine.kt
+++ b/src/main/java/com/yuyan/inputmethod/CustomEngine.kt
@@ -58,8 +58,8 @@ object CustomEngine {
         "sina.com", "sohu.com", "139.com", "189.cn", "aliyun.com", "hotmail.com"
     )
 
-    // 邮箱后缀匹配正则：本地部分@域名部分（域名可含字母数字.-）
-    private val emailEndPattern = "([A-Za-z0-9._%+-]+)@([A-Za-z0-9.-]*)\\z".toRegex()
+    // 邮箱后缀匹配正则：本地部分（任意字符，支持中文）@域名部分（域名可含字母数字.-）
+    private val emailEndPattern = "(.+)@([A-Za-z0-9.-]*)\\z".toRegex()
 
     /**
      * 解析文本末尾的邮箱输入

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="engish_full_keyboard">数字行</string>
     <string name="lx17_with_left_prefix">乱序17键盘显示拼音选择</string>
     <string name="space_auto">英文单词自动追加空格</string>
+    <string name="email_suggestion">邮箱联想</string>
     <string name="emoji_setting">表情输入</string>
     <string name="emoji_input">候选词中显示Emoji表情</string>
     <string name="symbol_setting">符号输入</string>


### PR DESCRIPTION
## 功能说明

任意输入框、任意键盘模式（中文/英文/数字）下，光标前文本以 `本地部分@部分域名` 结尾时，候选栏联想常见邮箱域名，点选后自动补全：

- 输入 `abc@` → 候选栏显示 `qq.com`、`163.com`、`gmail.com` 等纯文本域名（普通联想样式，无图标）
- 继续输入按前缀过滤：`abc@q` → 只剩 qq 系；`abc@qq.c` → 继续 `qq.com`；输完 `abc@qq.com` 自然停止
- 本地部分支持中文、可为空：`张三@`、空输入框直接输 `@` 均触发
- 点选后仅删除 `@` 后已输入的部分，原样补全域名（不走花漾字转换、不加尾随空格）：`abc@q` + 点选 `qq.com` → `abc@qq.com`
- 域名严格长于已输入部分才联想（忽略大小写），无死循环
- 「输入设置」新增"邮箱联想"开关，默认开启
- 完全离线，无任何权限/网络新增，符合最小权限原则

## 实现方式

复用现有剪贴板联想链路（`DecodingInfo.cacheCandidates` → LiveData → 候选栏自动刷新）：

| 文件 | 改动 |
|---|---|
| `CustomEngine.kt` | 内置 12 个常见域名 + 正则解析 `parseEmailAtEnd` + 前缀过滤 `emailSuggestions` |
| `InputView.kt` | `onUpdateSelection` 模式分支前检测 `@` 后缀；`chooseAndUpdate` 域名分支（置于剪贴板分支之后，避免与剪贴板内容冲突）；`commitEmailDomain` 含重新解析中止守卫与常用语编辑守卫 |
| `ImeService.kt` | 新增 `commitRawText()`（原样上屏，不做花漾字转换） |
| `AppPrefs.kt` + `strings.xml` | "邮箱联想"开关（默认开启） |

防御性处理：光标移位/状态过期时点选候选自动中止不上屏；`isAssociate` 状态参与英文分支稳定性判断，避免候选残留。

## 测试

- 已在实机验证：中文/英文/数字模式下 `@` 触发、前缀过滤、补全上屏、停止条件、开关关闭、花漾字模式域名原样
- 上游 master 基线 cherry-pick 后 `assembleDebug` 编译通过

## 备注

上游合并后，主仓库 YuyanIme 的子模块指针可另行更新。
