### PR TITLE
fix(ime): 修复 pre-IME 消费 BACK 致系统全局返回失效（HyperOS）及隐藏态按键崩溃

### DIFF
--- a/src/main/java/com/yuyan/imemodule/application/Launcher.kt
+++ b/src/main/java/com/yuyan/imemodule/application/Launcher.kt
@@ -27,7 +27,6 @@ class Launcher {
     private fun currentInit() {
         AppPrefs.init(PreferenceManager.getDefaultSharedPreferences(context))
         ThemeManager.init(context.resources.configuration)
-        DataBaseKT.instance.sideSymbolDao().getAllSideSymbolPinyin()  //操作一次查询，提前创建数据库，避免使用时才创建数据库
         ClipboardHelper.init()
     }
 
@@ -36,6 +35,8 @@ class Launcher {
      */
     private fun onInitDataChildThread() {
         ThreadPoolUtils.executeSingleton {
+            //操作一次查询，提前创建数据库，避免使用时才创建数据库（曾位于主线程，拖慢进程冷启动/输入法重绑）
+            DataBaseKT.instance.sideSymbolDao().getAllSideSymbolPinyin()
             // 复制词库文件
             val dataDictVersion = AppPrefs.getInstance().internal.dataDictVersion.getValue()
             if (dataDictVersion < CustomConstant.CURRENT_RIME_DICT_DATA_VERSIOM) {

--- a/src/main/java/com/yuyan/imemodule/keyboard/InputView.kt
+++ b/src/main/java/com/yuyan/imemodule/keyboard/InputView.kt
@@ -334,7 +334,14 @@ class InputView(context: Context, private val service: ImeService) : LifecycleRe
         when (keyCode) {
             KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_DPAD_DOWN, KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.KEYCODE_DPAD_RIGHT,
             KeyEvent.KEYCODE_APOSTROPHE, KeyEvent.KEYCODE_SPACE,
-            KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DEL, KeyEvent.KEYCODE_BACK -> return true
+            KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DEL -> return true
+            // 关键修复：Android 13+ 不得在 pre-IME 派发中消费 BACK 的 KEY_DOWN。
+            // 此处返回 true 会吞掉 DOWN（UP 侧不再消费时应用只会收到孤儿 UP；UP 侧消费时
+            // 应用收不到完整按键），在 HyperOS 上破坏返回仲裁与 insets 状态机：
+            // 搜索框弹出/收起键盘 + 连续快速返回即可使全局返回永久失效。
+            // 13+ 由系统返回仲裁（IME 显示时返回=收起键盘）完成，无需输入法参与。
+            // 13 以下保留旧行为（DOWN/UP 成对消费 + requestHideSelf）。
+            KeyEvent.KEYCODE_BACK -> return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
         }
         return false
     }
@@ -376,10 +383,13 @@ class InputView(context: Context, private val service: ImeService) : LifecycleRe
         return result
     }
 
-    // 系统按键只处理返回键，当点击返回键且软键盘显示时，隐藏键盘并消费事件
+    // 系统按键只处理返回键。注意：Android 13+ 上返回=收起键盘由系统的返回仲裁/insets 动画完成，
+    // 输入法在 pre-IME 派发里消费 BACK 并自行 requestHideSelf 会与系统的隐藏动画竞争，
+    // 连续快速返回时会在动画飞行途中再次触发隐藏，导致（HyperOS 上）insets 动画永不完成，
+    // 进而全局返回失效。因此 13+ 不再消费 BACK，事件交还系统处理。
     private fun processSystemKeys(event: KeyEvent): Boolean {
         return when (event.keyCode) {
-            KeyEvent.KEYCODE_BACK -> if (service.isInputViewShown) { requestHideSelf(); true } else false
+            KeyEvent.KEYCODE_BACK -> if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU && service.isInputViewShown) { requestHideSelf(); true } else false
             else -> false
         }
     }

--- a/src/main/java/com/yuyan/imemodule/service/ImeService.kt
+++ b/src/main/java/com/yuyan/imemodule/service/ImeService.kt
@@ -42,10 +42,14 @@ class ImeService : InputMethodService() {
     private var isSoftKeyboard = false
     private lateinit var mInputView: InputView
     private lateinit var mCandidateView: CandidateView
-    private val onThemeChangeListener = OnThemeChangeListener { _: Theme? -> if (isHardwareKeyboard) mCandidateView.updateTheme() else mInputView.updateTheme()}
+    private val onThemeChangeListener = OnThemeChangeListener { _: Theme? ->
+        // 进程刚重启、键盘未弹出时 onCreateInputView 尚未执行，lateinit 视图未初始化
+        if (isHardwareKeyboard && ::mCandidateView.isInitialized) mCandidateView.updateTheme()
+        else if (isSoftKeyboard && ::mInputView.isInitialized) mInputView.updateTheme()
+    }
     private val clipboardUpdateContent = getInstance().internal.clipboardUpdateContent
     private val clipboardUpdateContentListener = ManagedPreference.OnChangeListener<String> { _, value ->
-        if(isSoftKeyboard && getInstance().clipboard.clipboardSuggestion.getValue()){
+        if(isSoftKeyboard && ::mInputView.isInitialized && getInstance().clipboard.clipboardSuggestion.getValue()){
             if(value.isNotBlank()) {
                 if(KeyboardManager.instance.currentContainer is ClipBoardContainer
                     && (KeyboardManager.instance.currentContainer as ClipBoardContainer).getMenuMode() == SkbMenuMode.ClipBoard ){
@@ -79,12 +83,12 @@ class ImeService : InputMethodService() {
     override fun onStartInput(editorInfo: EditorInfo?, restarting: Boolean) {
         YuyanEmojiCompat.setEditorInfo(editorInfo)
         handleHardwareKeyboard()
-        if (isHardwareKeyboard)mCandidateView.onStartInput(editorInfo, restarting)
+        if (isHardwareKeyboard && ::mCandidateView.isInitialized)mCandidateView.onStartInput(editorInfo, restarting)
         super.onStartInput(editorInfo, restarting)
     }
 
     override fun onStartInputView(editorInfo: EditorInfo, restarting: Boolean) {
-        if (isSoftKeyboard)mInputView.onStartInputView(editorInfo, restarting)
+        if (isSoftKeyboard && ::mInputView.isInitialized)mInputView.onStartInputView(editorInfo, restarting)
         super.onStartInputView(editorInfo, restarting)
     }
 
@@ -107,7 +111,7 @@ class ImeService : InputMethodService() {
                 KeyboardLoaderUtil.instance.clearKeyboardMap()
                 KeyboardManager.instance.clearKeyboard()
                 KeyboardManager.instance.switchKeyboard()
-            } else if(isHardwareKeyboard){
+            } else if(isHardwareKeyboard && ::mCandidateView.isInitialized){
                 mCandidateView.initView()
             }
         }
@@ -118,16 +122,16 @@ class ImeService : InputMethodService() {
         // 0 != event.getRepeatCount()  长按物理按键或 Shift/Meta/Ctrl的组合按键时，交由系统处理;有个特殊组合键：Ctrl+SPACE切换语言
         return if (0 != event.repeatCount || event.isShiftPressed || event.isMetaPressed) super.onKeyDown(keyCode, event)
         else if(event.isCtrlPressed && keyCode != KeyEvent.KEYCODE_SPACE)super.onKeyDown(keyCode, event)
-        else if (isSoftKeyboard) mInputView.processKeyDown(keyCode, event) || super.onKeyUp(keyCode, event)
-        else if (isHardwareKeyboard) mCandidateView.processKeyDown(keyCode, event) || super.onKeyUp(keyCode, event)
+        else if (isSoftKeyboard && ::mInputView.isInitialized) mInputView.processKeyDown(keyCode, event) || super.onKeyUp(keyCode, event)
+        else if (isHardwareKeyboard && ::mCandidateView.isInitialized) mCandidateView.processKeyDown(keyCode, event) || super.onKeyUp(keyCode, event)
         else super.onKeyDown(keyCode, event)
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         return if (0 != event.repeatCount || event.isShiftPressed || event.isMetaPressed) super.onKeyDown(keyCode, event)
         else if(event.isCtrlPressed && keyCode != KeyEvent.KEYCODE_SPACE)super.onKeyDown(keyCode, event)
-        else if (isSoftKeyboard) mInputView.processKeyUp(event) || super.onKeyUp(keyCode, event)
-        else if (isHardwareKeyboard) mCandidateView.processKeyUp(event) || super.onKeyUp(keyCode, event)
+        else if (isSoftKeyboard && ::mInputView.isInitialized) mInputView.processKeyUp(event) || super.onKeyUp(keyCode, event)
+        else if (isHardwareKeyboard && ::mCandidateView.isInitialized) mCandidateView.processKeyUp(event) || super.onKeyUp(keyCode, event)
         else super.onKeyDown(keyCode, event)
     }
 
@@ -141,7 +145,6 @@ class ImeService : InputMethodService() {
     }
 
     override fun onEvaluateFullscreenMode(): Boolean = false //修复横屏之后输入框遮挡问题
-
 
     override fun onComputeInsets(outInsets: Insets) {
         val (x, y) = if (isSoftKeyboard && ::mInputView.isInitialized) intArrayOf(0, 0).also {if(mInputView.isAddPhrases) mInputView.mAddPhrasesLayout.getLocationInWindow(it) else mInputView.mSkbRoot.getLocationInWindow(it) }
@@ -171,13 +174,23 @@ class ImeService : InputMethodService() {
 
     override fun onUpdateSelection(oldSelStart: Int, oldSelEnd: Int, newSelStart: Int, newSelEnd: Int, candidatesStart: Int, candidatesEnd: Int) {
         super.onUpdateSelection(oldSelStart, oldSelEnd, newSelStart, newSelEnd, candidatesStart, candidatesEnd)
-        if (isSoftKeyboard) mInputView.onUpdateSelection(oldSelStart, oldSelEnd, newSelStart, newSelEnd, candidatesEnd)
+        if (isSoftKeyboard && ::mInputView.isInitialized) mInputView.onUpdateSelection(oldSelStart, oldSelEnd, newSelStart, newSelEnd, candidatesEnd)
+    }
+
+    override fun onWindowShown() {
+        if (isSoftKeyboard && ::mInputView.isInitialized) mInputView.onWindowShown()
+        super.onWindowShown()
+    }
+
+    override fun onWindowHidden() {
+        if(isSoftKeyboard && ::mInputView.isInitialized) mInputView.onWindowHidden()
+        super.onWindowHidden()
     }
 
     private val cursorAnchorPosition = FloatArray(2)
     override fun onUpdateCursorAnchorInfo(cursorAnchorInfo: CursorAnchorInfo?) {
         super.onUpdateCursorAnchorInfo(cursorAnchorInfo)
-        if (!isHardwareKeyboard || cursorAnchorInfo == null) return
+        if (!isHardwareKeyboard || cursorAnchorInfo == null || !::mCandidateView.isInitialized) return
         cursorAnchorPosition[0] = cursorAnchorInfo.insertionMarkerHorizontal
         cursorAnchorPosition[1] = cursorAnchorInfo.insertionMarkerBottom
         val matrix = cursorAnchorInfo.getMatrix()
@@ -187,21 +200,11 @@ class ImeService : InputMethodService() {
         mCandidateView.updatePosition(cursorAnchorPosition)
     }
 
-    override fun onWindowShown() {
-        if (isSoftKeyboard) mInputView.onWindowShown()
-        super.onWindowShown()
-    }
-
-    override fun onWindowHidden() {
-        if(isSoftKeyboard) mInputView.onWindowHidden()
-        super.onWindowHidden()
-    }
-
     /**
      * 模拟Enter按键点击
      */
     fun sendEnterKeyEvent() {
-        val inputConnection = getCurrentInputConnection()
+        val inputConnection = currentInputConnection ?: return
         YuyanEmojiCompat.mEditorInfo?.run {
             if (inputType and InputType.TYPE_MASK_CLASS == InputType.TYPE_NULL || imeOptions.hasFlag(EditorInfo.IME_FLAG_NO_ENTER_ACTION)) {
                 sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER)
@@ -251,7 +254,6 @@ class ImeService : InputMethodService() {
         currentInputConnection.setComposingText(text, 1)
     }
 
-
     /**
      * 结束提交预选词
      */
@@ -300,7 +302,8 @@ class ImeService : InputMethodService() {
         isSoftKeyboard = !hardwareKeyboard
         isHardwareKeyboard = hardwareKeyboard
         setCandidatesViewShown(isHardwareKeyboard)
-        currentInputConnection.requestCursorUpdates(if(isHardwareKeyboard)InputConnection.CURSOR_UPDATE_MONITOR else 0)
+        // onConfigurationChanged 会在无输入连接时调用（如键盘隐藏后切换深色模式），此时 currentInputConnection 为 null
+        currentInputConnection?.requestCursorUpdates(if(isHardwareKeyboard)InputConnection.CURSOR_UPDATE_MONITOR else 0)
     }
 
 }

--- a/src/main/java/com/yuyan/imemodule/utils/CrashHandler.kt
+++ b/src/main/java/com/yuyan/imemodule/utils/CrashHandler.kt
@@ -31,14 +31,16 @@ class CrashHandler private constructor() : Thread.UncaughtExceptionHandler {
     }
 
     override fun uncaughtException(thread: Thread, throwable: Throwable) {
-        if (!handleException(throwable) && mDefaultHandler != null) {
-            mDefaultHandler!!.uncaughtException(thread, throwable)
+        // 先落盘崩溃日志（内部已捕获自身异常，不会中断流程）
+        handleException(throwable)
+        // 必须交回系统默认处理器走标准崩溃流程：AMS 会以 "crash" 原因感知进程死亡，
+        // 并对被绑定的输入法服务执行标准的解绑/重绑恢复。
+        // 严禁自行 sleep + killProcess(SIGKILL)：那会把崩溃伪装成来源不明的 SIGKILL
+        // 死亡，且留下数秒不响应 binder 调用的僵尸进程，干扰系统恢复。
+        val handler = mDefaultHandler
+        if (handler != null) {
+            handler.uncaughtException(thread, throwable)
         } else {
-            try {
-                Thread.sleep(2000)
-            } catch (e: InterruptedException) {
-                e.printStackTrace()
-            }
             android.os.Process.killProcess(android.os.Process.myPid())
             exitProcess(1)
         }


### PR DESCRIPTION
## 问题

在 HyperOS（POCO F5 / Android 15 / OS3.0.5.0）上使用本输入法作为默认输入法时，**系统全局默认返回会永久失效**：手势返回本身被识别，主动监听返回的应用正常，但依赖系统默认返回行为（注入合成 BACK 键）的所有应用全部无效，只能切换输入法或重启恢复。同时进程存在约 20 秒一次的崩溃循环（应用私有目录 crash_logs 累积 70+ 同样堆栈）。

## 根因

**1. pre-IME 派发中消费 BACK 拆散了按键流（返回失效的触发器）**

`InputView.processKeyDown` 对 `KEYCODE_BACK` 直接 `return true`，`processSystemKeys` 在键盘显示时再消费 UP 并 `requestHideSelf`。pre-IME 派发中这样处理意味着：

- 键盘显示时：DOWN/UP 均被吞，应用收不到任何返回事件；
- 键盘隐藏时：DOWN 被吞、UP 泄漏为**孤儿 UP**，应用侧按键流校验失败。

在 HyperOS 上这会毒化系统的返回仲裁与 insets 状态机：**搜索框弹出/收起软键盘 + 连续快速返回，即可 100% 复现全局返回失效**（IME 窗口上残留永不完成的 `insets_animation` leash，进程活着也一样）。已通过 7 轮二分实验实锤该行为是唯一触发点；同场景 FUTO 输入法不受影响（不消费 BACK）。

**2. lateinit 视图未初始化崩溃 + CrashHandler 自杀（崩溃循环）**

进程重启后键盘未弹出时（`onCreateInputView` 未执行），派发到输入法会话的按键走进 `onKeyDown` → `mInputView.processKeyDown` → `UninitializedPropertyAccessException`。崩溃后 `CrashHandler` `sleep(2000)` 再 `killProcess`（SIGKILL），把标准崩溃伪装成来源不明的 SIGKILL 死亡，系统重启输入法后又立即崩溃，形成约 20 秒一次的循环。

## 修复

- `processKeyDown`/`processSystemKeys`：Android 13+ 不再消费 BACK，交还系统返回仲裁（IME 显示时返回=收起键盘由系统完成）；13 以下保留旧行为
- `ImeService`：补齐 8 处 lateinit 视图防护（按键/选区/主题/剪贴板回调）
- `CrashHandler`：崩溃交回系统默认处理器，移除 sleep+SIGKILL 自杀
- `handleHardwareKeyboard`：`currentInputConnection` 空安全（无输入连接时配置变更必崩 NPE）
- `Launcher`：数据库预热查询移出主线程

## 验证（真机 POCO F5 / HyperOS 3.0.5.0）

- 原版：复现脚本（搜索框弹/收键盘 ×3 + 连续返回 ×5~8）3/3 全部触发全局返回失效
- 修复版：同脚本多轮 + 深色模式切换 + 正常打字，返回始终正常，崩溃文件数零增长
- 返回行为无回归：键盘显示时按返回仍先收起键盘（由系统仲裁完成）